### PR TITLE
CORE-2500: guard against SDK type regressions in the Angular example

### DIFF
--- a/examples/angular/package.json
+++ b/examples/angular/package.json
@@ -15,7 +15,7 @@
     "@angular/platform-browser": "19.2.2",
     "@angular/platform-browser-dynamic": "19.2.2",
     "@angular/router": "19.2.2",
-    "@jam.dev/recording-links": "^0.3.1",
+    "@jam.dev/recording-links": "^0.3.2",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "0.15.0"

--- a/examples/angular/tsconfig.json
+++ b/examples/angular/tsconfig.json
@@ -9,7 +9,9 @@
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "skipLibCheck": true,
+    // Type-check dependency declarations (incl. @jam.dev/recording-links) so a
+    // broken SDK .d.ts surfaces here in CI instead of in a customer's build.
+    "skipLibCheck": false,
     "isolatedModules": true,
     "esModuleInterop": true,
     "experimentalDecorators": true,


### PR DESCRIPTION
[CORE-2500](https://linear.app/yay/issue/CORE-2500/fix-angular-snippet-verification-and-sdk-typescript-error) · closes #5 · depends on jamdotdev/sdk-recording-links#15

> **Draft — blocked on the SDK patch publishing.** Will go green once `@jam.dev/recording-links@0.3.2` is on npm (then refresh the lockfile).

## Why
- A default Angular app type-checks its dependencies' `.d.ts` (no `skipLibCheck`). The SDK's broken declaration surfaced `TS2339: Property '_loadRemoteScript' does not exist on type 'InitializeOptions'` (#5) and blocked the build.
- This example had `skipLibCheck: true`, so it **masked** the bug — CI here stayed green while real consumers broke.

## Change
- `examples/angular/tsconfig.json`: `skipLibCheck: false` — so a broken SDK `.d.ts` fails in our CI, not in a customer's build.
- `examples/angular/package.json`: bump `@jam.dev/recording-links` to `^0.3.2` (the patch that fixes the type — sdk-recording-links#15).

## Verification (local, against the SDK#15 build)
- `ng build` with `skipLibCheck: false` + the fixed SDK → passes, no TS2339 (previously failed).
- RL link verification e2e → "Domain verified!".

## Before merge
1. Merge + publish sdk-recording-links#15 (`release:patch` → `0.3.2`).
2. `bun install` to lock `0.3.2`, push lockfile, confirm CI green.